### PR TITLE
Update checkForStopWords to:

### DIFF
--- a/client/src/lib/util/translate.ts
+++ b/client/src/lib/util/translate.ts
@@ -32,9 +32,15 @@ export function translate({
 }
 
 export function checkForStopWords(queryString: string): string {
-  const queryStringWords = queryString.split(/[\s\W]+/)
+  if (queryString.includes('"')) {
+    return queryString
+  }
+  const queryStringWords = queryString.split(/\W+/)
+  if (queryStringWords.length === 1) {
+    return queryString
+  }
   for (const word of queryStringWords) {
-    if (!config.advancedSearch.stopWords.includes(word)) {
+    if (word !== '' && !config.advancedSearch.stopWords.includes(word)) {
       return queryString
     }
   }

--- a/client/src/test/unit/lib/util/translate.spec.ts
+++ b/client/src/test/unit/lib/util/translate.spec.ts
@@ -1,7 +1,10 @@
+import { advancedSearch } from '../../../../config/advancedSearch/advancedSearch'
+import config from '../../../../config/config'
 import { checkForStopWords } from '../../../../lib/util/translate'
 
 describe('translate', () => {
   describe('checkForStopWords', () => {
+    config.advancedSearch = advancedSearch()
     it('returns search string with quotes', () => {
       const mockQueryString = 'within from, (without)'
       expect(checkForStopWords(mockQueryString)).toEqual(`"${mockQueryString}"`)


### PR DESCRIPTION
- Not add double quotes if the search string already contains double quotes
- Not add quotes if there is only a single word
- Ignore empty strings when checking against the list of stop words (caused by non-word characters at the beginning or end of the query string)