### PR TITLE
Fix for race condition involving OAuth and RTK query

### DIFF
--- a/client/src/features/results/ResultsPage.tsx
+++ b/client/src/features/results/ResultsPage.tsx
@@ -83,7 +83,8 @@ const getScopedResultsComponent: any = (
 const title = 'Results Page'
 
 const ResultsPage: React.FC = () => {
-  useAuthentication()
+  const auth = useAuthentication()
+
   const dispatch = useAppDispatch()
   const { tab, subTab } = useParams<keyof ResultsTab>() as ResultsTab
   const paramPrefix = getParamPrefix(tab)
@@ -127,6 +128,9 @@ const ResultsPage: React.FC = () => {
     ? (urlParams.get(`${paramPrefix}s`) as string)
     : undefined
 
+  // Do not let RTK query serve the cached response if the user is logged in
+  const forceRefetch = auth.isAuthenticated
+
   /*
    Query will be skipped if the user has entered empty search string
    Or if there are no search params visible in the URL string, indicating
@@ -145,7 +149,11 @@ const ResultsPage: React.FC = () => {
     },
     {
       skip:
-        searchStringWithFacets === '' || fromLandingPage || tab !== queryTab,
+        auth.isLoading === true ||
+        searchStringWithFacets === '' ||
+        fromLandingPage ||
+        tab !== queryTab,
+      forceRefetch,
     },
   )
 

--- a/client/src/lib/auth/helper.ts
+++ b/client/src/lib/auth/helper.ts
@@ -36,7 +36,7 @@ export async function verifyToken(token: string): Promise<ITokenObject> {
 
     const { payload } = await jose.jwtVerify(token, jwks, {})
     // console.log('raw token:', token)
-    // console.log('parsed token:', payload, JSON.stringify(payload, null, 2))
+    console.log('parsed token:', payload, JSON.stringify(payload, null, 2))
     return payload as ITokenObject
   } catch (error) {
     console.error('Failed to verify token:', error)

--- a/client/src/lib/hooks/useAuthentication.ts
+++ b/client/src/lib/hooks/useAuthentication.ts
@@ -3,7 +3,7 @@ import { useAuth } from 'react-oidc-context'
 import config from '../../config/config'
 import { verifyToken } from '../auth/helper'
 
-export default function useAuthentication(): void {
+export default function useAuthentication(): AuthContextProps {
   const auth = useAuth()
 
   if (config.env.featureMyCollections) {
@@ -17,4 +17,5 @@ export default function useAuthentication(): void {
       // console.log('Not authenticated')
     }
   }
+  return auth
 }


### PR DESCRIPTION
1. Skip RTK query until auth is loaded.
2. Force RTK query to refetch if there's an authenticated user.